### PR TITLE
Fix use of sudo in install_doctest.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ It will install the library into `usr/doctest/`, so it will be accessible with:
 ```c++
 #include <doctest/doctest.h>
 ```
-In order to make the run successful, run the script in *sudo* mode:
+The script is executed with the command:
 ```shell
-sudo ./doctest_installer.sh
+./doctest_installer.sh
 ```
 
 ## article.tex <div id='template'/>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A python script which help you to download and convert to mp3 from YouTube.
 ## updater.py <div id='pip'/>
 A python script which help you to update all python's installed packages with pip.
 
-## doctest_installer.sh <div id='doctest'/>
+## install_doctest.sh <div id='doctest'/>
 A simple installer for the C++ library of doctest.
 It will install the library into `usr/doctest/`, so it will be accessible with:
 ```c++
@@ -21,7 +21,7 @@ It will install the library into `usr/doctest/`, so it will be accessible with:
 ```
 The script is executed with the command:
 ```shell
-./doctest_installer.sh
+./install_doctest.sh
 ```
 
 ## article.tex <div id='template'/>

--- a/install_doctest.sh
+++ b/install_doctest.sh
@@ -1,8 +1,13 @@
+#
+
 echo "Cloning the repository..."
 git clone https://github.com/doctest/doctest.git
+
 echo "Installing doctest..."
-mkdir -p /usr/local/include/doctest
-mv ./doctest/doctest/doctest.h /usr/local/include/doctest/doctest.h
+sudo mkdir -p /usr/local/include/doctest
+sudo mv ./doctest/doctest/doctest.h /usr/local/include/doctest/doctest.h
+
 echo "Cleaning up..."
 rm -rf ./doctest
+
 echo "Done!"


### PR DESCRIPTION
I think it's better to run only the necessary commands (`mkdir` and `mv`) with sudo, instead of the whole script.